### PR TITLE
Add item check for /radio and remove player from radio if item is lost

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -48,9 +48,12 @@ end
 --- sprawdza czy komenda /radio jest włączony
 
 RegisterCommand('radio', function(source, args)
-    if Config.enableCmd then
-      enableRadio(true)
-    end
+  TriggerServerEvent("ls-radio:checkcount")
+end)
+
+RegisterNetEvent('ls-radio:hasradio')
+AddEventHandler('ls-radio:hasradio', function()
+  enableRadio(true)
 end, false)
 
 

--- a/server/server.lua
+++ b/server/server.lua
@@ -9,8 +9,21 @@ ESX.RegisterUsableItem('radio', function(source)
 
 end)
 
+-- Only opens radio with /radio if player has item
 
--- checking is player have item
+RegisterServerEvent('ls-radio:checkcount')
+AddEventHandler('ls-radio:checkcount', function()
+	local _source = source
+	local xPlayer = ESX.GetPlayerFromId(_source)
+	if xPlayer.getInventoryItem('radio').count >= 1 then
+		TriggerClientEvent('ls-radio:hasradio', _source)
+	else 
+		TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'You dont have a radio, buy one at your local store', length = 7000})
+	end
+end)
+
+
+-- Removes player from radio channel if radio item is lost
 
 Citizen.CreateThread(function()
   while true do
@@ -22,9 +35,7 @@ Citizen.CreateThread(function()
               if xPlayer.getInventoryItem('radio').count == 0 then
 
                 local source = xPlayers[i]
-                TriggerClientEvent('ls-radio:onRadioDrop', source)
-
-                break
+                TriggerEvent("TokoVoip:removePlayerFromAllRadio", source)
               end
             end
           end


### PR DESCRIPTION
/radio was able to be used even if you didn't have the item, this will now check the players inventory to see if they have one. If they do, the radio will open. If they don't it will inform them to buy one.

This also fixes the issue where players are not removed from radio channels when their radio is dropped or otherwise removed from their inventory.